### PR TITLE
fix for flipped (upside down) BNO055 sensor

### DIFF
--- a/IMUReader.cpp
+++ b/IMUReader.cpp
@@ -53,6 +53,8 @@ void IMUReader::init(uint8_t *offsets) {
     imu_.setSensorOffsets(offsets);
   }
   imu_.setExtCrystalUse(true);
+  imu_.setAxisRemap(Adafruit_BNO055::REMAP_CONFIG_P7);
+  imu_.setAxisSign(Adafruit_BNO055::REMAP_SIGN_P7);
 
   // time 2 + orientation 4 + angular_velocy 3 + linear_acceleration 3
   imu_msg_.data = (float*)malloc(sizeof(float)*12);


### PR DESCRIPTION
cabot2-ace's BNO055 is placed upside down.
It looks like BNO055's axis setting should be changed accordingly. 

I added two lines to set P7 axis setting (default=P1).
P25 of [BNO055 datasheet](https://cdn-shop.adafruit.com/datasheets/BST_BNO055_DS000_12.pdf)
