### PR TITLE
when touch_raw is unstable, it is displayed as warning

### DIFF
--- a/TouchReader.cpp
+++ b/TouchReader.cpp
@@ -94,6 +94,10 @@ void TouchReader::check_touch_raw(int16_t touch_raw)
         diag_status_ = 2; //error
         diag_message_ = "touch_raw is constant at 0";
       }
+  } else if(touch_raw < -20) {
+      diag_status_ = 1; //warning
+      count_ = 0;
+      diag_message_ = "touch_raw is unstable";
   } else {
       diag_status_ = 0;
       count_ = 0;


### PR DESCRIPTION
The value of touch_raw becomes a large negative number, and there have been several instances where, despite touching, it does not proceed. Therefore, it will be displayed as a warning in diagnostics.


![Screenshot from 2024-04-08 11-00-13](https://github.com/CMU-cabot/cabot-arduino-ace/assets/101164062/5bde03ac-fccf-40bb-b846-256f5424a0b8)
